### PR TITLE
fix stack problem

### DIFF
--- a/rpn.js
+++ b/rpn.js
@@ -309,12 +309,14 @@ rpn["Generate"] = function(exp){
 					//※優先順位が同じなのは結合法則がright to leftのものだけスタックに積んである
 					while( ope_stack[depth].length > 0 ){
 						var ope = ope_stack[depth].shift();
-						Polish.push( ope );
 						//演算優先度が、スタック先頭の演算子以上ならば、続けて式に演算子を積む
 						if( OperateTable[ope].Order >= OperateTable[op].Order ){
+							Polish.push( ope );
 							continue;
 						}
 						else{
+							//演算優先度が、スタック先頭の演算子より低いならば、スタックに戻す
+							ope_stack[depth].unshift(ope);
 							break;
 						}
 					}


### PR DESCRIPTION
#1 

演算子の優先度を比較する際に、
```javascript
var ope = ope_stack[depth].shift();
Polish.push(ope);
```
により、最終結果に適用させた後に、
```javascript
if (this.OperateTable[ope].Order >= this.OperateTable[op].Order) {
}
```
で比較しているので１つずれたまま適用されてしまうようです。

比較して正しければPolish.push(ope);を行い、間違っていればunshift()で元のスタックに戻すように変更しました。